### PR TITLE
fix diff_rbg

### DIFF
--- a/scripts/indexer_rgb.js
+++ b/scripts/indexer_rgb.js
@@ -1,11 +1,11 @@
 function diff(a, b) {
-	const ar = (a >> 16) & 0xFF,
-		ag = (a >> 8) & 0xFF,
-		ab = a & 0xFF;
+	const ar = (a >> 24) & 0xFF,
+		ag = (a >> 16) & 0xFF,
+		ab = (a >> 8) & 0xFF;
 	// get in
-	const br = (b >> 16) & 0xFF,
-		bg = (b >> 8) & 0xFF,
-		bb = b & 0xFF;
+	const br = (b >> 24) & 0xFF,
+		bg = (b >> 16) & 0xFF,
+		bb = (b >> 8) & 0xFF;
 	const dr = Math.abs(ar - br),
 		dg = Math.abs(ag - bg),
 		db = Math.abs(ab - bb);


### PR DESCRIPTION
the diff_rbg function might have wrong calculation( same happens in pictologic)

change preview: 
left-origin figure; middle - after changes; right - before changes
![U 235PT{1@P`LJ 0$9}07CP](https://user-images.githubusercontent.com/55009845/195288371-5c56dbd5-f49b-45c2-840f-4e793494f7ce.png)
 